### PR TITLE
Upgrade "install_requires" versions and make Travis deploy it as a Python wheel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
 deploy:
   provider: pypi
   user: mottosso
+  distributions: "sdist bdist_wheel"
   password:
     secure: pSUCNg5n0NsmPaJPT+BcYJnnItXXwR52cPAC2E6FEVLzKf7cCdln+bpdv5v11yh9ub8FBmAjRP24eZ2Dx7QD7Cia3S33YuZpiorijD1FUB5AOdn8TFc2uEQgfhKkCHXFJbSy7DchHePw2OV7FE5+TmAx0MZvQ7ajLiriKegwvJQ=
   on:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[metadata]
+# This includes the license file in the wheel.
+license_file = LICENSE.txt
+
+[bdist_wheel]
+# This produces a "universal" (Py2+3) wheel.
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -37,14 +37,14 @@ setup(
         "console_scripts": ["pyblish = pyblish.cli:main"]
     },
     install_requires=[
-        "pyblish-base==1.5.4",
+        "pyblish-base==1.7.2",
         # "pyblish-hiero==1.0.0",  # Awaiting upload to PyPI
-        "pyblish-houdini==1.0.0",
-        "pyblish-maya==2.1.2",
-        "pyblish-nuke==2.0.3",
+        "pyblish-houdini==1.0.1",
+        "pyblish-maya==2.1.7",
+        "pyblish-nuke==2.1.2",
         # "pyblish-modo==0.0.2",
-        "pyblish-lite==0.7.4",
-        "pyblish-qml==1.4.5",
+        "pyblish-lite==0.8.3",
+        "pyblish-qml==1.8.2",
         # pyblish-standalone==0.1.0,
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "pyblish-nuke==2.1.2",
         # "pyblish-modo==0.0.2",
         "pyblish-lite==0.8.3",
-        "pyblish-qml==1.8.2",
+        "pyblish-qml==1.8.3",
         # pyblish-standalone==0.1.0,
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "pyblish-nuke==2.1.2",
         # "pyblish-modo==0.0.2",
         "pyblish-lite==0.8.3",
-        "pyblish-qml==1.8.3",
+        "pyblish-qml==1.8.4",
         # pyblish-standalone==0.1.0,
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "pyblish-nuke==2.1.2",
         # "pyblish-modo==0.0.2",
         "pyblish-lite==0.8.3",
-        "pyblish-qml==1.8.4",
+        "pyblish-qml==1.8.5",
         # pyblish-standalone==0.1.0,
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ classifiers = [
 
 setup(
     name="pyblish",
-    version="1.5.4",
+    version="1.6.0",
     description="Plug-in driven automation framework for content",
     long_description="Collection of latest supported "
                      "combinations of Pyblish projects",


### PR DESCRIPTION
Fixes #4.

It would make me very happy if the pyblish-qml wheel PR [**here**](https://github.com/pyblish/pyblish-qml/pull/298) could get merged so then this PR can include it too and then it'll be official that all popular Pyblish modules have been _wheelified_, lol.

